### PR TITLE
Increase verbosity level for to show deauth attempts based on the implentation for airsnare

### DIFF
--- a/airjack.py
+++ b/airjack.py
@@ -925,7 +925,7 @@ class WiFiCracker:
                 '-i', iface,
                 '-b', bssid,
                 '-w', self.capture_file,
-                '-v'  # Always use verbose to see deauth attempts
+                '-vvv'  # Always use verbose to see deauth attempts
             ]
 
             if not self.args.deauth:


### PR DESCRIPTION
the previous code didn't print the deauthenticating logs from the airsnore since it's set as debug which is enabled by using `-vvv`

https://github.com/rtulke/airsnare/blob/90a4b2cdbedb323b03295b68dc293d053794caed/src/terminal.h#L69

https://github.com/rtulke/airsnare/blob/90a4b2cdbedb323b03295b68dc293d053794caed/src/log.h#L28